### PR TITLE
Fix sorting logic in Security/Group/GetList.php

### DIFF
--- a/core/src/Revolution/Processors/Security/Group/GetList.php
+++ b/core/src/Revolution/Processors/Security/Group/GetList.php
@@ -106,9 +106,10 @@ class GetList extends GetListProcessor
                 'OR:description:LIKE' => '%' . $query . '%',
             ]);
         }
+        $sortby = $this->getProperty('sort','name');
+        $dir = $this->getProperty('dir','ASC');
         $c->sortby('parent', 'asc');
-        $c->sortby('id', 'asc');
-        
+        $c->sortby($sortby, $dir);
         return $c;
     }
 }


### PR DESCRIPTION
Fix sorting in security/group/GetList accordingly to the header comment

### What does it do?
The header comment says 
"
 * @param string $sort (optional) The column to sort by. Defaults to name.
 * @param string $dir (optional) The direction of the sort. Defaults to ASC.
"
but actually, the sort was based on id with no use of $sort or $dir, direction is always ASC...

### Why is it needed?
This PR fixes this using 'name' as the default sort and $dir to configure the sort direction

### How to test
Open ACL of groups and see how groups are now sorted according to their names...

### Related issue(s)/PR(s)
not found